### PR TITLE
Update to Cake.Frosting 0.31.0

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,13 +3,9 @@
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="myget-market6" value="https://www.myget.org/F/market6/api/v3/index.json" />
-    <add key="myget-cake" value="https://www.myget.org/F/cake/api/v3/index.json" />
     <add key="ProGet" value="http://packages.mk6.local:9999/nuget/main/" />
   </packageSources>
   <config>
     <add key="DefaultPushSource" value="https://www.myget.org/F/market6/api/v3/index.json" protocolVersion="3" />
   </config>
-  <disabledPackageSources>
-    <add key="myget-cake" value="true" />
-  </disabledPackageSources>
 </configuration>

--- a/src/BuildTestRunner/BuildTestRunner.csproj
+++ b/src/BuildTestRunner/BuildTestRunner.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="0.1.0" />
+    <PackageReference Include="Cake.Frosting" Version="0.31.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="0.1.0" />
+    <PackageReference Include="Cake.Frosting" Version="0.31.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Tasks.DotNetCore/Tasks.DotNetCore.csproj
+++ b/src/Tasks.DotNetCore/Tasks.DotNetCore.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="0.1.0" />
+    <PackageReference Include="Cake.Frosting" Version="0.31.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Uses Cake.Core & Cake.Common 0.31.0 ( read more about improvements at https://cakebuild.net/blog/2018/12/cake-v0.31.0-released )
* 0.31.0 is on NuGet.org so nuget.config no longer needed